### PR TITLE
Replace real email addresses with example.com addresses

### DIFF
--- a/src/Customer/Api/Data/CustomerStubBuilder.php
+++ b/src/Customer/Api/Data/CustomerStubBuilder.php
@@ -32,7 +32,7 @@ class CustomerStubBuilder
      */
     private $defaultData = [
         CustomerInterface::ID => 10,
-        CustomerInterface::EMAIL => 'test@gmail.com',
+        CustomerInterface::EMAIL => 'joe.doe@example.com',
         CustomerInterface::FIRSTNAME => 'Joe',
         CustomerInterface::LASTNAME => 'Doe',
         CustomerInterface::WEBSITE_ID => 1

--- a/tests/Integration/Customer/Data/CustomerStubBuilderTest.php
+++ b/tests/Integration/Customer/Data/CustomerStubBuilderTest.php
@@ -29,7 +29,7 @@ class CustomerStubBuilderTest extends TestCase
     public function testBuildingCustomerStub(): void
     {
         $id = 56;
-        $email = 'test2@gmail.com';
+        $email = 'jan.kowalski@example.com';
         $firstName = 'Jan';
         $lastName = 'Kowalski';
 
@@ -51,7 +51,7 @@ class CustomerStubBuilderTest extends TestCase
         $customerStub = CustomerStubBuilder::customerStub()->withId($id)->build();
 
         $this->assertSame($id, $customerStub->getId());
-        $this->assertSame('test@gmail.com', $customerStub->getEmail());
+        $this->assertSame('joe.doe@example.com', $customerStub->getEmail());
         $this->assertSame('Joe', $customerStub->getFirstname());
         $this->assertSame('Doe', $customerStub->getLastname());
     }
@@ -66,7 +66,7 @@ class CustomerStubBuilderTest extends TestCase
         $customerStub = CustomerStubBuilder::customerStub()->build();
 
         $this->assertSame(10, $customerStub->getId());
-        $this->assertSame('test@gmail.com', $customerStub->getEmail());
+        $this->assertSame('joe.doe@example.com', $customerStub->getEmail());
         $this->assertSame('Joe', $customerStub->getFirstname());
         $this->assertSame('Doe', $customerStub->getLastname());
     }
@@ -78,8 +78,8 @@ class CustomerStubBuilderTest extends TestCase
      */
     public function testIfBuilderIsReusable(): void
     {
-        $exampleEmail1 = 'test4@gmail.com';
-        $exampleEmail2 = 'other@gmail.com';
+        $exampleEmail1 = 'first@example.com';
+        $exampleEmail2 = 'other@example.com';
         $exampleId = 17;
 
         $customerStubBuilder = CustomerStubBuilder::customerStub();

--- a/tests/Integration/Customer/FailingCustomerRepositoryStubBuilderTest.php
+++ b/tests/Integration/Customer/FailingCustomerRepositoryStubBuilderTest.php
@@ -54,7 +54,7 @@ class FailingCustomerRepositoryStubBuilderTest extends TestCase
         $customerRepositoryStub->save(new CustomerStub());
 
         $this->expectException(LocalizedException::class);
-        $customerRepositoryStub->get('test@gmail');
+        $customerRepositoryStub->get('test@invalid');
 
         $this->expectException(LocalizedException::class);
         $customerRepositoryStub->getById(33);


### PR DESCRIPTION
example.com is a reserved example domain, see https://www.iana.org/domains/reserved